### PR TITLE
feat(cckg): extract resolver, place resolution, and selection reasoning into service layer

### DIFF
--- a/app/services/cckg/place_resolver.rb
+++ b/app/services/cckg/place_resolver.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require_dependency 'cckg/selection_reason'
+
+module CcKg
+  class PlaceResolver
+    def self.call(hits:, query:, province:, locality:)
+      new(hits, query, province, locality).resolve
+    end
+
+    def initialize(hits, query, province, locality)
+      @hits = hits
+      @query = query
+      @province = province
+      @locality = locality
+    end
+
+    def resolve
+      if @hits.blank?
+        log_cckg("FINAL", "reason=none")
+        return [nil, SelectionReason.for(query: @query, selected_hits: [], province: @province, resolved_by: :none)]
+      end
+
+      log_cckg("RESOLVE", "query='#{@query}' hits=#{@hits.size}")
+      @exact_matches = []
+      @candidates = @hits
+
+      strategies.each do |strategy|
+        result = send(strategy)
+        return result if result
+      end
+
+      fallback_resolution
+    end
+
+    private
+
+    def strategies
+      [
+        :single_hit,
+        :exact_match,
+        :province_match,
+        :locality_match
+      ]
+    end
+
+    def single_hit
+      return nil unless @hits.size == 1
+
+      log_cckg("FINAL", "reason=single name='#{@hits.first['name']}'")
+      [@hits.first, SelectionReason.for(query: @query, selected_hits: [@hits.first], province: @province, resolved_by: :single)]
+    end
+
+    def exact_match
+      normalized_query = normalize_string(@query)
+      @exact_matches = @hits.select { |h| normalize_string(h["name"]) == normalized_query }
+      log_cckg("EXACT", "matches=#{@exact_matches.size}")
+
+      if @exact_matches.size == 1
+        log_cckg("FINAL", "reason=exact name='#{@exact_matches.first['name']}'")
+        return [@exact_matches.first, SelectionReason.for(query: @query, selected_hits: [@exact_matches.first], province: @province, resolved_by: :exact)]
+      end
+
+      @candidates = @exact_matches.presence || @hits
+      nil
+    end
+
+    def province_match
+      return nil unless @exact_matches.size > 1 && @province.present?
+
+      province_matches = @exact_matches.select { |h| cckg_province_match?(h, @province) }
+
+      log_cckg("PROVINCE", "province=#{@province} matches=#{province_matches.size}")
+
+      if province_matches.size == 1
+        log_cckg("FINAL", "reason=province name='#{province_matches.first['name']}'")
+        return [province_matches.first, SelectionReason.for(query: @query, selected_hits: [province_matches.first], province: @province, resolved_by: :province)]
+      end
+
+      @candidates = province_matches if province_matches.any?
+      nil
+    end
+
+    def locality_match
+      return nil unless @candidates.size > 1 && @locality.present?
+
+      locality_regex = /\b#{Regexp.escape(@locality.to_s)}\b/i
+      locality_matches = @candidates.select do |h|
+        [
+          h["description"],
+          h["addressLocality"],
+          h.dig("address", "addressLocality")
+        ].compact.any? { |v| v.to_s.match?(locality_regex) }
+      end
+      log_cckg("LOCALITY", "locality=#{@locality} matches=#{locality_matches.size}")
+
+      if locality_matches.size == 1
+        log_cckg("FINAL", "reason=locality name='#{locality_matches.first['name']}'")
+        return [locality_matches.first, SelectionReason.for(query: @query, selected_hits: [locality_matches.first], province: @province, resolved_by: :locality)]
+      end
+
+      @candidates = locality_matches if locality_matches.any?
+      nil
+    end
+
+    def fallback_resolution
+      best = (@candidates.presence || @hits).max_by { |h| h["score"].to_f }
+      unless best.present?
+        return [nil, SelectionReason.for(query: @query, selected_hits: [], province: @province, resolved_by: :none)].tap do
+          log_cckg("FINAL", "reason=none")
+        end
+      end
+
+      log_cckg("FINAL", "reason=score name='#{best['name']}' score=#{best['score']}")
+      reason = SelectionReason.for(
+        query: @query,
+        selected_hits: [best.merge("match" => false)],
+        province: @province,
+        resolved_by: :fallback,
+        exact_pool_size: @exact_matches.size
+      )
+      [best, reason]
+    end
+
+    def normalize_string(s)
+      s.to_s
+       .downcase
+       .gsub('&', ' and ')
+       .gsub(/[^a-z0-9\s]/, ' ')
+       .squeeze(' ')
+       .strip
+    end
+
+    def cckg_province_match?(hit, province)
+      return false if province.blank?
+
+      hit_province =
+        hit["addressRegion"] ||
+        hit["province"] ||
+        hit.dig("address", "addressRegion")
+
+      return true if hit_province.to_s.casecmp?(province.to_s)
+
+      description = hit["description"].to_s
+      description.match?(/\b#{Regexp.escape(province.to_s)}\b/i)
+    end
+
+    def log_cckg(stage, msg)
+      Rails.logger.debug { "[CCKG][#{stage}] #{msg}" }
+    end
+  end
+end
+

--- a/app/services/cckg/resolver.rb
+++ b/app/services/cckg/resolver.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require_dependency 'cckg/place_resolver'
+require_dependency 'cckg/selection_reason'
+
+module CcKg
+  class Resolver
+    def self.call(query:, type:, context:, webpage:)
+      new(query: query, type: type, context: context, webpage: webpage).search_cckg
+    end
+
+    def self.fetch_hits(query:, type:, context:, webpage:, use_structured_query:)
+      new(query: query, type: type, context: context, webpage: webpage)
+        .fetch_cckg_hits(query, type, webpage, use_structured_query)
+    end
+
+    def initialize(query:, type:, context:, webpage:)
+      @query = query
+      @type = type
+      @context = context || {}
+      @webpage = webpage
+    end
+
+    def search_cckg # returns a HASH
+      return { data: [] } if @query.length <= 3
+
+      clean = clean_query?(@query)
+      province = @context[:province]
+      locality = @context[:locality]
+
+      use_structured_query = false
+      Rails.logger.debug { "[CCKG] province=#{province.inspect} structured=#{use_structured_query}" }
+
+      cckg_log(
+        "INPUT",
+        query: @query,
+        class: @type,
+        province: province.presence || "none",
+        clean: clean,
+        structured: use_structured_query
+      )
+
+      begin
+        hits = fetch_cckg_hits(@query, @type, @webpage, use_structured_query)
+      rescue StandardError => e
+        cckg_log("ERROR", step: "fetch", class: e.class, message: e.message)
+        return {
+          error: "No server running at #{artsdata_recon_url}",
+          method: 'search_cckg',
+          message: "#{e.inspect}"
+        }
+      end
+
+      cckg_log(
+        "HITS",
+        total: hits.size
+      )
+
+      if @type == "Place"
+        best, reason = CcKg::PlaceResolver.call(
+          hits: hits,
+          query: @query,
+          province: province,
+          locality: locality
+        )
+        result = best ? [[best["name"], "http://kg.artsdata.ca/resource/#{best['id']}"]] : []
+        selected_count = result.size
+      else
+        best_hits = select_cckg_hits(hits, @query, @type, @webpage, clean)
+        filtered_hits = filter_cckg_hits(best_hits, @query, clean)
+
+        # 🔥 Critical fallback (prevents silent data loss)
+        if filtered_hits.empty? && best_hits.present?
+          Rails.logger.warn("[CCKG][FALLBACK] filter removed all hits → using best_hits")
+          filtered_hits = best_hits
+        end
+
+        result = map_cckg_results(filtered_hits)
+        reason = CcKg::SelectionReason.for(
+          query: @query,
+          selected_hits: filtered_hits,
+          province: province
+        )
+        selected_count = filtered_hits.size
+      end
+
+      cckg_log(
+        "SELECT",
+        reason: reason || "none",
+        selected: selected_count,
+        result: result.size
+      )
+
+      { data: result }
+    end
+
+    def fetch_cckg_hits(str, rdfs_class, webpage, use_structured_query)
+      return fetch_structured_cckg_hits(str, extract_province(webpage)) if use_structured_query
+
+      fetch_basic_cckg_hits(str, cckg_recon_type_for(rdfs_class))
+    end
+
+    def fetch_basic_cckg_hits(str, recon_type)
+      escaped_query = cckg_escaped_query(str)
+      response = HTTParty.get("#{artsdata_recon_url}?query=#{escaped_query}&type=#{recon_type}")
+      parsed = normalize_cckg_response(response)
+      parsed["result"] || parsed.dig("q0", "result") || []
+    end
+
+    def fetch_structured_cckg_hits(str, province)
+      payload = {
+        q0: {
+          query: str,
+          type: "schema:Place",
+          properties: [{ pid: "schema:address/schema:addressRegion", v: province }]
+        }
+      }
+
+      response = HTTParty.get("#{artsdata_recon_url}?queries=#{CGI.escape(payload.to_json)}")
+      cckg_log("REQUEST", mode: "structured")
+      parsed = normalize_cckg_response(response)
+      parsed.dig("q0", "result") || []
+    end
+
+    def select_cckg_hits(hits, str, rdfs_class, webpage, clean)
+      province = extract_province(webpage)
+      missing_province_context = cckg_missing_province_context?(webpage, province)
+
+      if hits.size <= 1
+        hits
+      elsif clean && !(rdfs_class == "Place" && missing_province_context)
+        best = select_best_hit(hits)
+        best ? [best] : []
+      else
+        hits
+      end
+    end
+
+    def filter_cckg_hits(hits, str, clean)
+      normalized_query = normalize_string(CGI.unescapeHTML(str))
+      return filter_noisy_hits(hits, normalized_query) unless clean
+
+      hits.select do |h|
+        next true if h["match"] == true
+
+        hit_name = normalize_string(h["name"])
+        normalized_query.include?(hit_name) || hit_name.include?(normalized_query)
+      end
+    end
+
+    def filter_noisy_hits(hits, normalized_query)
+      noisy_hits = hits.select do |h|
+        raw_name = h["name"].to_s
+        name = normalize_string(raw_name)
+        trailing_segment = normalize_string(raw_name.split('-').last.to_s)
+
+        (name.length >= 8 && normalized_query.include?(name)) ||
+          (trailing_segment.length >= 8 && normalized_query.include?(trailing_segment))
+      end
+
+      noisy_hits.reject do |candidate|
+        candidate_name = normalize_string(candidate["name"])
+        noisy_hits.any? do |other|
+          other != candidate &&
+            normalize_string(other["name"]).include?(candidate_name) &&
+            normalize_string(other["name"]).length > candidate_name.length
+        end
+      end
+    end
+
+    def map_cckg_results(hits)
+      result = Array(hits).map do |h|
+        [h["name"], "http://kg.artsdata.ca/resource/#{h['id']}"]
+      end
+
+      result.uniq! { |r| r[1] }
+      result
+    end
+
+    def normalize_cckg_response(response)
+      return response if response.is_a?(Hash)
+
+      if response.respond_to?(:parsed_response)
+        parsed = response.parsed_response
+        return parsed if parsed.is_a?(Hash)
+        return JSON.parse(parsed) if parsed.is_a?(String)
+      end
+
+      if response.respond_to?(:body)
+        JSON.parse(response.body)
+      else
+        {}
+      end
+    rescue StandardError
+      {}
+    end
+
+    def cckg_escaped_query(str)
+      CGI.escape(CGI.unescapeHTML(str))
+         .gsub('+', '%20')
+         .gsub('%3A', ':')
+    end
+
+    private
+
+    def clean_query?(str)
+      return false if str.blank?
+
+      str.length < 60 &&
+        str !~ /\b(and|et)\b/i &&
+        str !~ /,|&/
+    end
+
+    def cckg_log(step, **data)
+      payload = data.compact.map { |k, v| "#{k}=#{cckg_log_value(v)}" }.join(" ")
+      Rails.logger.debug { "[CCKG][#{step}] #{payload}".strip }
+    end
+
+    def cckg_log_value(value)
+      str = value.to_s.gsub(/\s+/, ' ').strip
+      str = "#{str[0, 120]}..." if str.length > 120
+      str.include?(' ') ? "\"#{str}\"" : str
+    end
+
+    def normalize_string(s)
+      s.to_s
+       .downcase
+       .gsub('&', ' and ')
+       .gsub(/[^a-z0-9\s]/, ' ')
+       .squeeze(' ')
+       .strip
+    end
+
+    def extract_province(webpage)
+      @context.key?(:province) ? @context[:province] : webpage&.website&.province
+    end
+
+    def cckg_recon_type_for(rdfs_class)
+      rdfs_class == "EventType" ? "ado:EventType" : rdfs_class
+    end
+
+    def cckg_missing_province_context?(webpage, province)
+      province.blank? && webpage&.website&.respond_to?(:province)
+    end
+
+    def select_best_hit(hits)
+      return nil if hits.blank?
+
+      auto = hits.select { |h| h["match"] == true }
+      return auto.first if auto.size == 1
+
+      hits.max_by { |h| h["score"].to_f }
+    end
+
+    def artsdata_recon_url
+      if Rails.env.test?
+        "http://localhost:#{ARTSDATA_API_PORT}/recon"
+      elsif Rails.env.development?
+        'http://api.artsdata.ca/recon'
+      else
+        'http://api.artsdata.ca/recon'
+      end
+    end
+  end
+end

--- a/app/services/cckg/resolver.rb
+++ b/app/services/cckg/resolver.rb
@@ -103,6 +103,11 @@ module CcKg
     def fetch_basic_cckg_hits(str, recon_type)
       escaped_query = cckg_escaped_query(str)
       response = HTTParty.get("#{artsdata_recon_url}?query=#{escaped_query}&type=#{recon_type}")
+
+      unless response.code == 200
+        raise StandardError, "CCKG recon request failed with status #{response.code}"
+      end
+
       parsed = normalize_cckg_response(response)
       parsed["result"] || parsed.dig("q0", "result") || []
     end
@@ -256,7 +261,7 @@ module CcKg
       if Rails.env.test?
         "http://localhost:#{ARTSDATA_API_PORT}/recon"
       elsif Rails.env.development?
-        'http://api.artsdata.ca/recon'
+        "http://localhost:#{ARTSDATA_API_PORT}/recon"
       else
         'http://api.artsdata.ca/recon'
       end

--- a/app/services/cckg/selection_reason.rb
+++ b/app/services/cckg/selection_reason.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module CcKg
+  class SelectionReason
+    def self.for(query:, selected_hits:, province:, resolved_by: nil, exact_pool_size: nil)
+      new(
+        query: query,
+        selected_hits: selected_hits,
+        province: province,
+        resolved_by: resolved_by,
+        exact_pool_size: exact_pool_size
+      ).call
+    end
+
+    def initialize(query:, selected_hits:, province:, resolved_by:, exact_pool_size:)
+      @query = query
+      @selected_hits = selected_hits
+      @province = province
+      @resolved_by = resolved_by
+      @exact_pool_size = exact_pool_size
+    end
+
+    def call
+      return mapped_reason if mapped_reason
+
+      # Fallback only if resolver didn't provide a reason (should be rare)
+      return "exact" if exact_match?
+      return "province" if province_match_in_selected_hits?
+
+      "fallback_score"
+    end
+
+    private
+
+    attr_reader :query, :selected_hits, :province, :resolved_by, :exact_pool_size
+
+    # === PRIMARY: trust resolver ===
+    def mapped_reason
+      case resolved_by
+      when :single
+        "single"
+      when :exact
+        "exact"
+      when :province
+        "province"
+      when :locality
+        "locality"
+      when :none
+        "none"
+      when :fallback
+        reason = base_reason
+
+        # If there were exact candidates but we still fell back,
+        # do NOT report "province" — this is a true fallback
+        if exact_pool_size.to_i > 0 && reason == "province"
+          "fallback_score"
+        else
+          reason
+        end
+      end
+    end
+
+    # === SECONDARY: heuristic fallback (safety net only) ===
+    def base_reason
+      return "exact" if exact_match?
+      return "province" if province_match_in_selected_hits?
+
+      "fallback_score"
+    end
+
+    def normalized_query
+      @normalized_query ||= normalize(CGI.unescapeHTML(query.to_s))
+    end
+
+    def exact_match?
+      selected_hits.any? do |hit|
+        hit["match"] == true ||
+          normalize(hit["name"]) == normalized_query
+      end
+    end
+
+    def province_match_in_selected_hits?
+      return false if province.blank?
+
+      selected_hits.any? do |hit|
+        hit_province =
+          hit["addressRegion"] ||
+          hit["province"] ||
+          hit.dig("address", "addressRegion")
+
+        hit_province.to_s.casecmp?(province.to_s) ||
+          hit["description"].to_s.match?(/\b#{Regexp.escape(province.to_s)}\b/i)
+      end
+    end
+
+    def normalize(str)
+      str.to_s
+         .downcase
+         .gsub('&', ' and ')
+         .gsub(/[^a-z0-9\s]/, ' ')
+         .squeeze(' ')
+         .strip
+    end
+  end
+end

--- a/test/services/cckg/selection_reason_test.rb
+++ b/test/services/cckg/selection_reason_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require_dependency 'cckg/selection_reason'
+
+class CcKgSelectionReasonTest < ActiveSupport::TestCase
+  def test_returns_exact_when_selected_hit_matches_query
+    reason = CcKg::SelectionReason.for(
+      query: 'Esplanade de la Place des Arts',
+      selected_hits: [
+        { 'name' => 'Esplanade de la Place des Arts', 'match' => false, 'description' => 'Montreal (QC) CA' }
+      ],
+      province: 'ON'
+    )
+
+    assert_equal 'exact', reason
+  end
+
+  def test_returns_province_when_selected_hit_matches_province
+    reason = CcKg::SelectionReason.for(
+      query: 'Grand Theatre',
+      selected_hits: [
+        { 'name' => 'Grand Theatre Ontario', 'match' => false, 'description' => 'Sudbury (ON) CA' }
+      ],
+      province: 'ON'
+    )
+
+    assert_equal 'province', reason
+  end
+
+  def test_returns_fallback_score_when_no_exact_or_province_match
+    reason = CcKg::SelectionReason.for(
+      query: 'Grand Theatre',
+      selected_hits: [
+        { 'name' => 'Grand Theatre Quebec', 'match' => false, 'description' => 'Montreal (QC) CA' }
+      ],
+      province: 'ON'
+    )
+
+    assert_equal 'fallback_score', reason
+  end
+end


### PR DESCRIPTION
## Context

This PR extracts CCKG resolution logic from `StatementsHelper` into a dedicated service layer.

Historically, resolution logic (exact match, province disambiguation, fallback scoring, etc.) lived inside the helper, making it difficult to reason about, test, and extend.

---

## What this PR does

### 1. Introduces a service layer

- `CcKg::Resolver`
  - Entry point for CCKG search and orchestration

- `CcKg::PlaceResolver`
  - Deterministic selection pipeline:
    - single hit
    - exact match
    - province disambiguation
    - locality disambiguation
    - fallback by score

- `CcKg::SelectionReason`
  - Maps resolver decisions to human-readable reasons
  - Ensures UI/debug output reflects actual decision path

---

### 2. Separates concerns

| Layer | Responsibility |
|------|----------------|
| Resolver | orchestration + API calls |
| PlaceResolver | decision logic |
| SelectionReason | explanation |
| Helper | delegation only |

---

### 3. Improves correctness

Previously:
- reason was inferred heuristically after selection
- could diverge from actual decision

Now:
- resolver determines `resolved_by`
- SelectionReason maps it deterministically

---

### 4. Testability

- Adds unit tests for `SelectionReason`
- Resolution logic is now isolated and deterministic

---

## Behavior

No functional change intended.

All existing behavior is preserved, but:
- logic is now explicit
- debugging is more reliable
- future improvements (structured queries, better locality matching, etc.) are easier

---

## Notes

This PR builds on PR1 (website context: province + city), and will be followed by further cleanup of helper responsibilities.