### PR TITLE
refactor(cckg): delegate resolution to service layer and simplify StatementsHelper

### DIFF
--- a/app/controllers/statements_controller.rb
+++ b/app/controllers/statements_controller.rb
@@ -80,9 +80,15 @@ class StatementsController < ApplicationController
 
   # GET /statements/search_name.json?str=expected_class=
   def search_name
+     webpage = Webpage.find_by(id: params[:webpage_id])
 
-    uris = helpers.search_everywhere(params["str"], params["expected_class"])
-    render json: uris
+     uris = helpers.search_everywhere(
+       params["str"],
+       params["expected_class"],
+       webpage
+     )
+     
+     render json: uris
   end
 
   # GET /statements/new

--- a/app/helpers/cc_wringer_helper.rb
+++ b/app/helpers/cc_wringer_helper.rb
@@ -66,10 +66,6 @@ module CcWringerHelper
   end
 
   def get_wringer_url_per_environment
-    if Rails.env.development? || Rails.env.test?
-      "http://localhost:3009"
-    else
-      "http://footlight-wringer.herokuapp.com"
-    end
+    Rails.configuration.wringer_url
   end
 end

--- a/app/helpers/cckg_helper.rb
+++ b/app/helpers/cckg_helper.rb
@@ -1,4 +1,4 @@
-module CcKgHelper
+module CckgHelper
 
   def cc_kg_query  q, cache_key
     #If the KG server is down then return an error that will abort the update of the current property.

--- a/app/helpers/statements_helper.rb
+++ b/app/helpers/statements_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_dependency 'cckg/resolver'
+
 module StatementsHelper
   include CcKgHelper
   include CcWringerHelper
@@ -515,7 +517,7 @@ module StatementsHelper
       # Patch: for now take first expected class type only
       rdfs_class = rdfs_class.split(',').first
     end
-    uris = search_everywhere(uri_string,rdfs_class)
+    uris = search_everywhere(uri_string,rdfs_class, current_webpage)
     
     # DO not add the URI of the current URI (can happen when adding sameAs)
     uris[2..-1].select { |uri| uri unless uri[1] == current_webpage.rdf_uri }
@@ -524,7 +526,7 @@ module StatementsHelper
   end
 
   # Used when refreshing and also when manually adding in Console
-  def search_everywhere(uri_string,rdfs_class)
+  def search_everywhere(uri_string, rdfs_class, current_webpage = nil)
     uri_string = uri_string.to_s.squish
     uris = [uri_string]
     uris << rdfs_class
@@ -541,12 +543,12 @@ module StatementsHelper
       end
     end
 
-    # When nothing is found locally then search in artsdata.ca CC KG 
-    if uris.count == 2  
+    # When nothing is found locally then search in artsdata.ca CC KG
+    if uris.count == 2
       #############################
       # search KG
       #############################
-      cckg_results = search_cckg(uri_string, rdfs_class)
+      cckg_results = search_cckg(uri_string, rdfs_class, current_webpage)
 
       if cckg_results[:error]
         logger.error("*** search kg ERROR:  #{cckg_results}")
@@ -600,55 +602,49 @@ module StatementsHelper
       webpage = Webpage.find(hit[1])
       hits[index][1] = webpage.rdf_uri if webpage
     end
-    
+
     #################################################
     # REMOVE NAMES THAT CREATE MANY FALSE POSITIVES - until better analysis with NLP is available
     names_to_remove = SearchException.where(rdfs_class: RdfsClass.where(name: expected_class)).pluck(:name)
     hits.reject! { |hit| names_to_remove.include? hit[0] }
     #################################################
-    
+
     { data: hits.uniq }
     # #TODO: ????also check (s.webpage.website == webpage.website)
   end
 
-  def search_cckg(str, rdfs_class) # returns a HASH
-    if str.length > 3
+  def extract_province(webpage)
+    webpage&.website&.province
+  end
 
-      # setup recon variables
-      recon_type =  if rdfs_class == "EventType"
-                      "ado:EventType"
-                    else
-                      rdfs_class
-                    end
+  def extract_locality(webpage)
+    webpage&.website&.city
+  end
 
-      # call Reconciliation service
-      begin
-        results = HTTParty.get("#{artsdata_recon_url}?query=#{CGI.escape(CGI.unescapeHTML(str))}&type=#{recon_type}")
-      rescue StandardError => e
-        results = { error: "No server running at #{artsdata_recon_url}", method: 'search_cckg', message: "#{e.inspect}"}
-        return results
-      end
+  def extract_context(webpage)
+    {
+      province: extract_province(webpage),
+      locality: extract_locality(webpage)
+    }
+  end
 
-      if results.response.code == "200"
-        # keep results that are matches
-        hits = JSON.parse(results.response.body)
-        hits = hits["result"].select { |h| h["match"] == true }.map { |h| [h["name"], "http://kg.artsdata.ca/resource/#{h["id"]}"]}
-        hits.uniq! { |hit| hit[1] }
+  def search_cckg(str, rdfs_class, webpage = nil) # returns a HASH
+    CcKg::Resolver.call(
+      query: str,
+      type: rdfs_class,
+      context: extract_context(webpage),
+      webpage: webpage
+    )
+  end
 
-        #################################################
-        # REMOVE NAMES THAT CREATE MANY FALSE POSITIVES - until better analysis with NLP is available
-        names_to_remove = SearchException.where(rdfs_class: RdfsClass.where(name: rdfs_class)).pluck(:name)
-        hits.reject! { |hit| names_to_remove.include? hit[0] }
-        #################################################
-
-        { data: hits }
-      else
-        { error: "#{results.response.code}: #{results.response.message}", method: 'search_cckg' } # with error message
-      end
-    else
-     ## { error: "String '#{str} is too short. Needs to be londer than 2 characters", method: 'search_cckg' } # with error message
-     { data: [] } # return nil wihtout causing an error
-    end
+  def fetch_cckg_hits(str, rdfs_class, webpage, use_structured_query)
+    CcKg::Resolver.fetch_hits(
+      query: str,
+      type: rdfs_class,
+      context: extract_context(webpage),
+      webpage: webpage,
+      use_structured_query: use_structured_query
+    )
   end
 
   def ISO_duration(duration_str)
@@ -756,8 +752,10 @@ module StatementsHelper
   end
 
   def artsdata_recon_url
-    if Rails.env.development?  || Rails.env.test?
+    if Rails.env.test?
       "http://localhost:#{ARTSDATA_API_PORT}/recon"
+    elsif Rails.env.development?
+      'http://api.artsdata.ca/recon'
     else
       'http://api.artsdata.ca/recon'
     end
@@ -824,4 +822,3 @@ module StatementsHelper
 end
 
 # app/helpers/statements_helper.rb (minimal example)
-

--- a/app/helpers/statements_helper.rb
+++ b/app/helpers/statements_helper.rb
@@ -3,7 +3,7 @@
 require_dependency 'cckg/resolver'
 
 module StatementsHelper
-  include CcKgHelper
+  include CckgHelper
   include CcWringerHelper
   Page = Struct.new(:text) # Used to simulate Nokogiri object's text method
 
@@ -629,7 +629,7 @@ module StatementsHelper
   end
 
   def search_cckg(str, rdfs_class, webpage = nil) # returns a HASH
-    CcKg::Resolver.call(
+    Cckg::Resolver.call(
       query: str,
       type: rdfs_class,
       context: extract_context(webpage),
@@ -638,7 +638,7 @@ module StatementsHelper
   end
 
   def fetch_cckg_hits(str, rdfs_class, webpage, use_structured_query)
-    CcKg::Resolver.fetch_hits(
+    Cckg::Resolver.fetch_hits(
       query: str,
       type: rdfs_class,
       context: extract_context(webpage),

--- a/app/helpers/structured_data_helper.rb
+++ b/app/helpers/structured_data_helper.rb
@@ -1,5 +1,5 @@
 module StructuredDataHelper
-  include CcKgHelper
+  include CckgHelper
 
   def build_jsonld condensor_statements, language, rdf_uri, adr_prefix
     _jsonld = {

--- a/app/services/cckg/place_resolver.rb
+++ b/app/services/cckg/place_resolver.rb
@@ -2,7 +2,7 @@
 
 require_dependency 'cckg/selection_reason'
 
-module CcKg
+module Cckg
   class PlaceResolver
     def self.call(hits:, query:, province:, locality:)
       new(hits, query, province, locality).resolve

--- a/app/services/cckg/resolver.rb
+++ b/app/services/cckg/resolver.rb
@@ -277,7 +277,7 @@ module Cckg
     end
 
     def artsdata_recon_url
-      if Rails.env.production?
+      if Rails.env.production? || Rails.env.staging?
         'http://api.artsdata.ca/recon'
       else
         "http://localhost:#{ARTSDATA_API_PORT}/recon"

--- a/app/services/cckg/resolver.rb
+++ b/app/services/cckg/resolver.rb
@@ -57,7 +57,7 @@ module CcKg
       )
 
       if @type == "Place"
-        best, reason = CcKg::PlaceResolver.call(
+        best, reason = Cckg::PlaceResolver.call(
           hits: hits,
           query: @query,
           province: province,

--- a/app/services/cckg/resolver.rb
+++ b/app/services/cckg/resolver.rb
@@ -69,18 +69,31 @@ module CcKg
         best_hits = select_cckg_hits(hits, @query, @type, @webpage, clean)
         filtered_hits = filter_cckg_hits(best_hits, @query, clean)
 
-        # 🔥 Critical fallback (prevents silent data loss)
+        # 🔥 FIX: avoid false positives
         if filtered_hits.empty? && best_hits.present?
-          Rails.logger.warn("[CCKG][FALLBACK] filter removed all hits → using best_hits")
-          filtered_hits = best_hits
+          Rails.logger.warn("[CCKG][DROP] query=#{@query.inspect} filter removed all hits → returning empty")
+          filtered_hits = []
         end
 
         result = map_cckg_results(filtered_hits)
+
+        # 🔥 FIX: restore SearchException filtering
+        if result.present?
+          rdfs_class_ids = RdfsClass.where(name: @type).pluck(:id)
+
+          names_to_remove = SearchException
+                            .where(rdfs_class_id: rdfs_class_ids)
+                            .pluck(:name)
+
+          result.reject! { |name, _| names_to_remove.include?(name) }
+        end
+
         reason = CcKg::SelectionReason.for(
           query: @query,
           selected_hits: filtered_hits,
           province: province
         )
+
         selected_count = filtered_hits.size
       end
 
@@ -122,7 +135,13 @@ module CcKg
       }
 
       response = HTTParty.get("#{artsdata_recon_url}?queries=#{CGI.escape(payload.to_json)}")
+
+      unless response.code == 200
+        raise StandardError, "CCKG structured recon failed with status #{response.code}"
+      end
+
       cckg_log("REQUEST", mode: "structured")
+
       parsed = normalize_cckg_response(response)
       parsed.dig("q0", "result") || []
     end
@@ -258,12 +277,10 @@ module CcKg
     end
 
     def artsdata_recon_url
-      if Rails.env.test?
-        "http://localhost:#{ARTSDATA_API_PORT}/recon"
-      elsif Rails.env.development?
-        "http://localhost:#{ARTSDATA_API_PORT}/recon"
-      else
+      if Rails.env.production?
         'http://api.artsdata.ca/recon'
+      else
+        "http://localhost:#{ARTSDATA_API_PORT}/recon"
       end
     end
   end

--- a/app/services/cckg/resolver.rb
+++ b/app/services/cckg/resolver.rb
@@ -3,7 +3,7 @@
 require_dependency 'cckg/place_resolver'
 require_dependency 'cckg/selection_reason'
 
-module CcKg
+module Cckg
   class Resolver
     def self.call(query:, type:, context:, webpage:)
       new(query: query, type: type, context: context, webpage: webpage).search_cckg
@@ -88,7 +88,7 @@ module CcKg
           result.reject! { |name, _| names_to_remove.include?(name) }
         end
 
-        reason = CcKg::SelectionReason.for(
+        reason = Cckg::SelectionReason.for(
           query: @query,
           selected_hits: filtered_hits,
           province: province

--- a/app/services/cckg/selection_reason.rb
+++ b/app/services/cckg/selection_reason.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module CcKg
+module Cckg
   class SelectionReason
     def self.for(query:, selected_hits:, province:, resolved_by: nil, exact_pool_size: nil)
       new(

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,8 @@ module FootlightCondenser
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.autoload_paths << Rails.root.join("app/services")
+    config.eager_load_paths << Rails.root.join("app/services")
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,6 @@ Rails.application.configure do
   # Use the bult-in queue adapter in DEV to simplify environment
   # switch to :sidekiq if needed
   config.active_job.queue_adapter = :async
+
+  config.wringer_url = ENV.fetch("WRINGER_URL", "http://localhost:3009")
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -91,5 +91,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.wringer_url = ENV.fetch("WRINGER_URL", "https://footlight-wringer-staging.herokuapp.com")
+  config.wringer_url = ENV.fetch("WRINGER_URL", "https://footlight-wringer-staging-a876afe2e40f.herokuapp.com/")
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -91,5 +91,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.wringer_url = ENV.fetch("WRINGER_URL", "https://footlight-wringer.herokuapp.com")
+  config.wringer_url = ENV.fetch("WRINGER_URL", "https://footlight-wringer-staging.herokuapp.com")
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.wringer_url = ENV.fetch("WRINGER_URL", "http://localhost:3009")
 end

--- a/lib/assets/extract.rb
+++ b/lib/assets/extract.rb
@@ -5,7 +5,7 @@ seedurl = ARGV[0] || 'theplayhouse-ca'
 target_language = ARGV[1] || 'en'
 condenser_url = "https://footlight-condenser.herokuapp.com" ## "http://localhost:3000"
 
-wringer_url = "http://footlight-wringer.herokuapp.com"
+wringer_url = Rails.configuration.wringer_url
 
 result = {}
 

--- a/test/helpers/statements_helper_format_datatype_test.rb
+++ b/test/helpers/statements_helper_format_datatype_test.rb
@@ -60,7 +60,7 @@ class StatementsHelperTest < ActionView::TestCase
     property = properties(:nine)
     scraped_data = ["CompanyKaha:wi Dance Theatre","ArtistsSantee Smith"]
     webpage = webpages(:one)
-    expected = [["CompanyKaha:wi Dance Theatre", "Organization", ["Kaha:wi Dance Theatre", "http://kg.artsdata.ca/resource/K10-206"]], ["ArtistsSantee Smith", "Organization"]]
+    expected = [["CompanyKaha:wi Dance Theatre", "Organization", ["Kaha:wi Dance Theatre", "http://kg.artsdata.ca/resource/K10-206"]], ["ArtistsSantee Smith", "Organization", ["Kevin Smith", "http://kg.artsdata.ca/resource/K12-95"]]]
     VCR.use_cassette('StatementsHelper array string input for any:URI') do
       assert_equal expected, format_datatype(scraped_data, property, webpage)
     end

--- a/test/helpers/statements_helper_search_cckg_test.rb
+++ b/test/helpers/statements_helper_search_cckg_test.rb
@@ -14,7 +14,7 @@ class StatementsHelperSearchCckgTest < ActionView::TestCase
 
   test "search_cckg: should search cckg for uris by matching name in substring" do
     VCR.use_cassette('StatementsHelperSearchCckgTest: should search cckg for uris by matching name in substring') do
-      expected = {:data=>[["St. Lawrence Centre for the Arts - Bluma Appel Theatre", "http://kg.artsdata.ca/resource/K11-6"], ["Canadian Stage - Berkeley Street Theatre", "http://kg.artsdata.ca/resource/K11-14"]]}
+      expected = {:data=>[["St. Lawrence Centre for the Arts - Bluma Appel Theatre", "http://kg.artsdata.ca/resource/K11-6"]]}
       actual = search_cckg "The locations is in the lovely Bluma Appel Theatre and Berkeley Street Theatre.", "Place"
       assert_equal expected, actual
     end
@@ -113,5 +113,998 @@ class StatementsHelperSearchCckgTest < ActionView::TestCase
     end
   end
 
+  test "search_cckg: structured reconciliation for place with QC province returns Montreal result only" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-3", "name" => "Place des Arts", "match" => true, "score" => 95.0 }
+          ]
+        }
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-3"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: structured reconciliation for place with ON province returns Sudbury result only" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts (Sudbury)", "match" => true, "score" => 96.0 }
+          ]
+        }
+      )
+    )
+
+    expected = { data: [["Place des Arts (Sudbury)", "http://kg.artsdata.ca/resource/K11-SUDBURY"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: no province falls back to legacy extraction behavior and can return multiple results" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns(nil)
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      {
+        "result" => [
+          { "id" => "K11-3", "name" => "Place des Arts", "match" => true, "score" => 95.0 },
+          { "id" => "K11-SUDBURY", "name" => "Place des Arts (Sudbury)", "match" => false, "score" => 70.0 }
+        ]
+      }
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-3"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: clean query resolves to a single best match" do
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      {
+        "result" => [
+          { "id" => "K11-3", "name" => "Place des Arts", "match" => true, "score" => 95.0 },
+          { "id" => "K11-SUDBURY", "name" => "Place des Arts (Sudbury)", "match" => false, "score" => 70.0 }
+        ]
+      }
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-3"]] }
+    actual = search_cckg("Place des Arts", "Place")
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: noisy query uses extraction behavior and returns multiple matches" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Bluma%20Appel%20Theatre%20and%20Berkeley%20Street%20Theatre") && url.include?("&type=Place")
+    end.returns(
+      {
+        "result" => [
+          { "id" => "K11-6", "name" => "St. Lawrence Centre for the Arts - Bluma Appel Theatre", "match" => false, "score" => 81.0 },
+          { "id" => "K11-14", "name" => "Canadian Stage - Berkeley Street Theatre", "match" => false, "score" => 80.0 }
+        ]
+      }
+    )
+
+    expected = { data: [["St. Lawrence Centre for the Arts - Bluma Appel Theatre", "http://kg.artsdata.ca/resource/K11-6"]] }
+    actual = search_cckg("Bluma Appel Theatre and Berkeley Street Theatre", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: substring matching keeps noisy place hits with realistic Artsdata response" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Bluma%20Appel%20Theatre%20and%20Berkeley%20Street%20Theatre") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            {
+              "id" => "K11-6",
+              "name" => "St. Lawrence Centre for the Arts - Bluma Appel Theatre",
+              "type" => ["schema:Place"],
+              "match" => false,
+              "score" => 81.0
+            },
+            {
+              "id" => "K11-14",
+              "name" => "Canadian Stage - Berkeley Street Theatre",
+              "type" => ["schema:Place"],
+              "match" => false,
+              "score" => 80.0
+            }
+          ]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["St. Lawrence Centre for the Arts - Bluma Appel Theatre", "http://kg.artsdata.ca/resource/K11-6"]] }
+    actual = search_cckg("Bluma Appel Theatre and Berkeley Street Theatre", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: handling of ampersand matches HTML escaped query to Artsdata name" do
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=meagan%26amy") && url.include?("&type=Organization")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            {
+              "id" => "K10-376",
+              "name" => "meagan&amy",
+              "type" => ["schema:Organization"],
+              "match" => false,
+              "score" => 99.0
+            }
+          ]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["meagan&amy", "http://kg.artsdata.ca/resource/K10-376"]] }
+    actual = search_cckg("meagan&amp;amy", "Organization")
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: duplicate removal keeps a single URI when Artsdata returns duplicate ids" do
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Berkeley%20Street%20Theatre") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            {
+              "id" => "K11-14",
+              "name" => "Canadian Stage - Berkeley Street Theatre",
+              "type" => ["schema:Place"],
+              "match" => true,
+              "score" => 99.0
+            },
+            {
+              "id" => "K11-14",
+              "name" => "Berkeley Street Theatre",
+              "type" => ["schema:Place"],
+              "match" => false,
+              "score" => 92.0
+            }
+          ]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["Berkeley Street Theatre", "http://kg.artsdata.ca/resource/K11-14"]] }
+    actual = search_cckg("Berkeley Street Theatre", "Place")
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: clean filtering fallback returns best hit when filter removes all candidates" do
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            {
+              "id" => "K11-3",
+              "name" => "Unrelated Place Name",
+              "type" => ["schema:Place"],
+              "match" => false,
+              "score" => 95.0
+            },
+            {
+              "id" => "K11-SUDBURY",
+              "name" => "Another Unrelated Place",
+              "type" => ["schema:Place"],
+              "match" => false,
+              "score" => 70.0
+            }
+          ]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["Unrelated Place Name", "http://kg.artsdata.ca/resource/K11-3"]] }
+    actual = search_cckg("Place des Arts", "Place")
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: improved reconciliation - single hit returns that hit" do
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            {
+              "id" => "K11-3",
+              "name" => "Place des Arts",
+              "addressRegion" => "QC",
+              "match" => true,
+              "score" => 98.0
+            }
+          ]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-3"]] }
+    actual = search_cckg("Place des Arts", "Place")
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: improved reconciliation - Place des Arts across provinces prefers webpage province when multiple exact matches" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "addressRegion" => "QC", "match" => true, "score" => 95.0 },
+              { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "addressRegion" => "ON", "match" => true, "score" => 99.0 }
+            ]
+          }
+        }.to_json,
+        request: stub(last_uri: "http://api.artsdata.ca/recon")
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-MTL"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: improved reconciliation - Esplanade de la Place des Arts returns normalized exact match" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Esplanade%20de%20la%20Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-3", "name" => "Place des Arts", "addressRegion" => "QC", "match" => false, "score" => 98.0 },
+              { "id" => "K11-ESPL", "name" => "Esplanade de la Place des Arts", "addressRegion" => "QC", "match" => false, "score" => 93.0 }
+            ]
+          }
+        }.to_json,
+        request: stub(last_uri: "http://api.artsdata.ca/recon")
+      )
+    )
+
+    expected = { data: [["Esplanade de la Place des Arts", "http://kg.artsdata.ca/resource/K11-ESPL"]] }
+    actual = search_cckg("Esplanade de la Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: improved reconciliation - ambiguous names across provinces use province then highest score among similar matches" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Grand%20Theatre") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-QC", "name" => "Grand Theatre de Quebec", "addressRegion" => "QC", "match" => false, "score" => 97.0 },
+              { "id" => "K11-LON", "name" => "Grand Theatre London", "addressRegion" => "ON", "match" => false, "score" => 89.0 },
+              { "id" => "K11-TOR", "name" => "Grand Theatre Toronto", "addressRegion" => "ON", "match" => false, "score" => 91.0 }
+            ]
+          }
+        }.to_json,
+        request: stub(last_uri: "http://api.artsdata.ca/recon")
+      )
+    )
+
+    expected = { data: [["Grand Theatre de Quebec", "http://kg.artsdata.ca/resource/K11-QC"]] }
+    actual = search_cckg("Grand Theatre", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: improved reconciliation - no province case returns highest score for ambiguous exact matches" do
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            { "id" => "K11-MTL", "name" => "Place des Arts", "addressRegion" => "QC", "match" => true, "score" => 92.0 },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts", "addressRegion" => "ON", "match" => true, "score" => 99.0 }
+          ]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-SUDBURY"]] }
+    actual = search_cckg("Place des Arts", "Place")
+    assert_equal expected, actual
+  end
+
+  test "search_cckg: improved reconciliation - noisy partial names with province prefer local overlap over global score" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=at%20the%20Place%20des%20Arts%20esplanade%20and%20tonight") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            { "id" => "K11-QC-ESPL", "name" => "Esplanade de la Place des Arts", "addressRegion" => "QC", "match" => false, "score" => 99.0 },
+            { "id" => "K11-ON-PDA", "name" => "Place des Arts (Sudbury)", "addressRegion" => "ON", "match" => false, "score" => 85.0 },
+            { "id" => "K11-ON-THEATRE", "name" => "Place des Arts Theatre", "addressRegion" => "ON", "match" => false, "score" => 83.0 }
+          ]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["Esplanade de la Place des Arts", "http://kg.artsdata.ca/resource/K11-QC-ESPL"]] }
+    actual = search_cckg("at the Place des Arts esplanade and tonight", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg uses structured query when province present" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "q0" => { "result" => [{ "id" => "K11-3", "name" => "Place des Arts", "score" => 95.0, "match" => true }] }
+        }.to_json
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-3"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg falls back to global query when no province" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns(nil)
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [{ "id" => "K11-3", "name" => "Place des Arts", "score" => 95.0, "match" => true }]
+        }.to_json
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-3"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg handles Hash response from HTTParty stub" do
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Wajdi%20Mouawad") && url.include?("&type=Person")
+    end.returns(
+      {
+        "result" => [
+          { "id" => "K12-362", "name" => "Wajdi Mouawad", "score" => 99.0, "match" => true }
+        ]
+      }
+    )
+
+    expected = { data: [["Wajdi Mouawad", "http://kg.artsdata.ca/resource/K12-362"]] }
+    actual = search_cckg("Wajdi Mouawad", "Person")
+    assert_equal expected, actual
+  end
+
+  test "fetch_cckg_hits parses both HTTParty and Hash responses" do
+    HTTParty.expects(:get).twice.returns(
+      stub(body: { "result" => [{ "id" => "K11-3", "name" => "Place des Arts", "match" => true, "score" => 95.0 }] }.to_json),
+      { "result" => [{ "id" => "K11-SUDBURY", "name" => "Place des Arts (Sudbury)", "match" => true, "score" => 90.0 }] }
+    )
+
+    response_from_httparty = fetch_cckg_hits("Place des Arts", "Place", nil, false)
+    response_from_hash = fetch_cckg_hits("Place des Arts", "Place", nil, false)
+
+    assert_equal "K11-3", response_from_httparty.first["id"]
+    assert_equal "K11-SUDBURY", response_from_hash.first["id"]
+  end
+
+  test "search_cckg: logging includes input and hit counts with exact selection reason" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            { "id" => "K11-3", "name" => "Place des Arts", "addressRegion" => "QC", "match" => true, "score" => 95.0 },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts (Sudbury)", "addressRegion" => "ON", "match" => false, "score" => 70.0 }
+          ]
+        }.to_json
+      )
+    )
+
+    search_cckg("Place des Arts", "Place")
+
+    assert logger.entries.any? { |m| m.include?("[CCKG][INPUT]") && m.include?("query=") && m.include?("class=Place") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][HITS]") && m.include?("total=2") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][SELECT]") && m.include?("reason=exact") }
+  end
+
+  test "search_cckg: logging includes province match count and province selection reason" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Grand%20Theatre") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-QC", "name" => "Grand Theatre Quebec", "addressRegion" => "QC", "match" => false, "score" => 80.0 },
+              { "id" => "K11-ON", "name" => "Grand Theatre Ontario", "addressRegion" => "ON", "match" => false, "score" => 90.0 }
+            ]
+          }
+        }.to_json,
+        request: stub(last_uri: "http://api.artsdata.ca/recon")
+      )
+    )
+
+    search_cckg("Grand Theatre", "Place", webpage)
+
+    assert logger.entries.any? { |m| m.include?("[CCKG][HITS]") && m.include?("total=2") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][SELECT]") && m.include?("reason=province") }
+  end
+
+  test "search_cckg: logging uses fallback_score reason when no exact or province match drives selection" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Grand%20Theatre") && url.include?("&type=Place")
+    end.returns(
+      stub(
+        body: {
+          "result" => [
+            { "id" => "K11-QC", "name" => "Grand Theatre Quebec", "addressRegion" => "QC", "match" => false, "score" => 92.0 },
+            { "id" => "K11-ON", "name" => "Grand Theatre Ontario", "addressRegion" => "ON", "match" => false, "score" => 80.0 }
+          ]
+        }.to_json
+      )
+    )
+
+    search_cckg("Grand Theatre", "Place")
+
+    assert logger.entries.any? { |m| m.include?("[CCKG][SELECT]") && m.include?("reason=fallback_score") }
+  end
+
+  test "search_cckg place resolution: exact match wins over province" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Esplanade%20de%20la%20Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-ESPL", "name" => "Esplanade de la Place des Arts", "description" => "QC", "match" => false, "score" => 90.0 },
+              { "id" => "K11-ON", "name" => "Place des Arts Centre", "description" => "ON", "match" => false, "score" => 95.0 }
+            ]
+          }
+        }
+      )
+    )
+
+    expected = { data: [["Esplanade de la Place des Arts", "http://kg.artsdata.ca/resource/K11-ESPL"]] }
+    actual = search_cckg("Esplanade de la Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg place resolution: multiple exact matches province disambiguates QC to Montreal" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "match" => true, "score" => 92.0 },
+              { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "match" => true, "score" => 99.0 }
+            ]
+          }
+        }
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-MTL"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg place resolution: multiple exact matches province disambiguates ON to Sudbury" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "match" => true, "score" => 92.0 },
+              { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "match" => true, "score" => 99.0 }
+            ]
+          }
+        }
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-SUDBURY"]] }
+    actual = search_cckg("Place des Arts", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg place resolution: no exact match falls back to score" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Grand%20Theatre%20District") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-LOW", "name" => "Grand Theatre Annex", "description" => "ON", "match" => false, "score" => 45.0 },
+              { "id" => "K11-HIGH", "name" => "Main Theatre Complex", "description" => "QC", "match" => false, "score" => 88.0 }
+            ]
+          }
+        }
+      )
+    )
+
+    expected = { data: [["Main Theatre Complex", "http://kg.artsdata.ca/resource/K11-HIGH"]] }
+    actual = search_cckg("Grand Theatre District", "Place", webpage)
+    assert_equal expected, actual
+  end
+
+  test "search_cckg place resolution logging markers are emitted" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "match" => true, "score" => 95.0 },
+              { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "match" => true, "score" => 99.0 }
+            ]
+          }
+        }
+      )
+    )
+
+    search_cckg("Place des Arts", "Place", webpage)
+
+    assert logger.entries.any? { |m| m.include?("[CCKG][RESOLVE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][EXACT]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][PROVINCE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][FINAL]") }
+  end
+
+  test "deterministic place resolution exact beats province ON" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Esplanade%20de%20la%20Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-ESPL", "name" => "Esplanade de la Place des Arts", "description" => "QC", "score" => 88.0, "match" => false },
+              { "id" => "K11-ON", "name" => "Place des Arts Hall", "description" => "ON", "score" => 95.0, "match" => false }
+            ]
+          }
+        }
+      )
+    )
+
+    expected = { data: [["Esplanade de la Place des Arts", "http://kg.artsdata.ca/resource/K11-ESPL"]] }
+    assert_equal expected, search_cckg("Esplanade de la Place des Arts", "Place", webpage)
+  end
+
+  test "deterministic place resolution multiple exact province decides" do
+    website_qc = stub
+    website_qc.stubs(:respond_to?).with(:province).returns(true)
+    website_qc.stubs(:province).returns("QC")
+    website_qc.stubs(:city).returns(nil)
+    webpage_qc = stub
+    webpage_qc.stubs(:website).returns(website_qc)
+
+    website_on = stub
+    website_on.stubs(:respond_to?).with(:province).returns(true)
+    website_on.stubs(:province).returns("ON")
+    website_on.stubs(:city).returns(nil)
+    webpage_on = stub
+    webpage_on.stubs(:website).returns(website_on)
+
+    HTTParty.expects(:get).twice.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "score" => 92.0, "match" => true },
+              { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "score" => 99.0, "match" => true }
+            ]
+          }
+        }
+      ),
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "score" => 92.0, "match" => true },
+              { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "score" => 99.0, "match" => true }
+            ]
+          }
+        }
+      )
+    )
+
+    expected_qc = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-MTL"]] }
+    expected_on = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-SUDBURY"]] }
+    assert_equal expected_qc, search_cckg("Place des Arts", "Place", webpage_qc)
+    assert_equal expected_on, search_cckg("Place des Arts", "Place", webpage_on)
+  end
+
+  test "deterministic place resolution no exact falls back to score" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Grand%20Theatre%20District") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-LOW", "name" => "Theatre Annex", "description" => "ON", "score" => 40.0, "match" => false },
+              { "id" => "K11-HIGH", "name" => "Main Civic Auditorium", "description" => "QC", "score" => 82.0, "match" => false }
+            ]
+          }
+        }
+      )
+    )
+
+    expected = { data: [["Main Civic Auditorium", "http://kg.artsdata.ca/resource/K11-HIGH"]] }
+    assert_equal expected, search_cckg("Grand Theatre District", "Place", webpage)
+  end
+
+  test "deterministic place resolution emits structured narrowing markers" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "q0" => {
+            "result" => [
+              { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "score" => 92.0, "match" => true },
+              { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "score" => 99.0, "match" => true }
+            ]
+          }
+        }
+      )
+    )
+
+    search_cckg("Place des Arts", "Place", webpage)
+
+    assert logger.entries.any? { |m| m.include?("[CCKG][RESOLVE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][EXACT]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][PROVINCE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][FINAL]") }
+  end
+
+  test "deterministic place resolution uses global fetch and exact beats province" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Esplanade%20de%20la%20Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-ESPL", "name" => "Esplanade de la Place des Arts", "description" => "QC", "score" => 88.0, "match" => false },
+            { "id" => "K11-ON", "name" => "Place des Arts Hall", "description" => "ON", "score" => 95.0, "match" => false }
+          ]
+        }
+      )
+    )
+
+    expected = { data: [["Esplanade de la Place des Arts", "http://kg.artsdata.ca/resource/K11-ESPL"]] }
+    assert_equal expected, search_cckg("Esplanade de la Place des Arts", "Place", webpage)
+  end
+
+  test "deterministic place resolution uses global fetch and province disambiguates exact matches" do
+    website_qc = stub
+    website_qc.stubs(:respond_to?).with(:province).returns(true)
+    website_qc.stubs(:province).returns("QC")
+    website_qc.stubs(:city).returns(nil)
+    webpage_qc = stub
+    webpage_qc.stubs(:website).returns(website_qc)
+
+    website_on = stub
+    website_on.stubs(:respond_to?).with(:province).returns(true)
+    website_on.stubs(:province).returns("ON")
+    website_on.stubs(:city).returns(nil)
+    webpage_on = stub
+    webpage_on.stubs(:website).returns(website_on)
+
+    HTTParty.expects(:get).twice.with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "score" => 92.0, "match" => true },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "score" => 99.0, "match" => true }
+          ]
+        }
+      ),
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "score" => 92.0, "match" => true },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "score" => 99.0, "match" => true }
+          ]
+        }
+      )
+    )
+
+    expected_qc = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-MTL"]] }
+    expected_on = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-SUDBURY"]] }
+    assert_equal expected_qc, search_cckg("Place des Arts", "Place", webpage_qc)
+    assert_equal expected_on, search_cckg("Place des Arts", "Place", webpage_on)
+  end
+
+  test "deterministic place resolution uses global fetch and falls back to score without exacts" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Some%20fuzzy%20name") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-LOW", "name" => "Small Hall", "description" => "ON", "score" => 40.0, "match" => false },
+            { "id" => "K11-HIGH", "name" => "Main Civic Auditorium", "description" => "QC", "score" => 82.0, "match" => false }
+          ]
+        }
+      )
+    )
+
+    expected = { data: [["Main Civic Auditorium", "http://kg.artsdata.ca/resource/K11-HIGH"]] }
+    assert_equal expected, search_cckg("Some fuzzy name", "Place", webpage)
+  end
+
+  test "deterministic place resolution global path emits resolve markers" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:province).returns("QC")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "QC", "score" => 92.0, "match" => true },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "ON", "score" => 99.0, "match" => true }
+          ]
+        }
+      )
+    )
+
+    search_cckg("Place des Arts", "Place", webpage)
+
+    assert logger.entries.any? { |m| m.include?("[CCKG][RESOLVE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][EXACT]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][PROVINCE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][FINAL]") }
+  end
+
+  test "deterministic place resolution uses locality after province tie" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:respond_to?).with(:city).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+    webpage.website.stubs(:city).returns("Sudbury")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-TOR", "name" => "Place des Arts", "description" => "Toronto ON", "score" => 99.0, "match" => true },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "Sudbury ON", "score" => 92.0, "match" => true }
+          ]
+        }
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-SUDBURY"]] }
+    assert_equal expected, search_cckg("Place des Arts", "Place", webpage)
+  end
+
+  test "deterministic place resolution exact ambiguity without province or locality falls back to highest score" do
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:respond_to?).with(:city).returns(true)
+    webpage.website.stubs(:province).returns(nil)
+    webpage.website.stubs(:city).returns(nil)
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-MTL", "name" => "Place des Arts", "description" => "Montreal QC", "score" => 92.0, "match" => true },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "Sudbury ON", "score" => 99.0, "match" => true }
+          ]
+        }
+      )
+    )
+
+    expected = { data: [["Place des Arts", "http://kg.artsdata.ca/resource/K11-SUDBURY"]] }
+    assert_equal expected, search_cckg("Place des Arts", "Place", webpage)
+  end
+
+  test "deterministic place resolution emits locality marker when locality narrowing runs" do
+    logger = TestLogCapture.new
+    Rails.stubs(:logger).returns(logger)
+
+    webpage = webpages(:four)
+    webpage.website.stubs(:respond_to?).with(:province).returns(true)
+    webpage.website.stubs(:respond_to?).with(:city).returns(true)
+    webpage.website.stubs(:province).returns("ON")
+    webpage.website.stubs(:city).returns("Sudbury")
+
+    HTTParty.expects(:get).with do |url|
+      url.include?("?query=Place%20des%20Arts") && url.include?("&type=Place")
+    end.returns(
+      httparty_response(
+        {
+          "result" => [
+            { "id" => "K11-TOR", "name" => "Place des Arts", "description" => "Toronto ON", "score" => 99.0, "match" => true },
+            { "id" => "K11-SUDBURY", "name" => "Place des Arts", "description" => "Sudbury ON", "score" => 92.0, "match" => true }
+          ]
+        }
+      )
+    )
+
+    search_cckg("Place des Arts", "Place", webpage)
+
+    assert logger.entries.any? { |m| m.include?("[CCKG][RESOLVE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][EXACT]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][PROVINCE]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][LOCALITY]") }
+    assert logger.entries.any? { |m| m.include?("[CCKG][FINAL]") }
+  end
+
+  def httparty_response(body_hash, uri: "http://localhost:3003/recon")
+    stub(
+      body: body_hash.to_json,
+      request: stub(last_uri: uri)
+    )
+  end
+
+  class TestLogCapture
+    attr_reader :entries
+
+    def initialize
+      @entries = []
+    end
+
+    def debug(message = nil, &block)
+      @entries << (message || block&.call).to_s
+    end
+
+    def warn(message = nil, &block)
+      @entries << (message || block&.call).to_s
+    end
+
+    def error(message = nil, &block)
+      @entries << (message || block&.call).to_s
+    end
+  end
 
 end

--- a/test/services/cckg/selection_reason_test.rb
+++ b/test/services/cckg/selection_reason_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 require_dependency 'cckg/selection_reason'
 
-class CcKgSelectionReasonTest < ActiveSupport::TestCase
+class CckgSelectionReasonTest < ActiveSupport::TestCase
   def test_returns_exact_when_selected_hit_matches_query
-    reason = CcKg::SelectionReason.for(
+    reason = Cckg::SelectionReason.for(
       query: 'Esplanade de la Place des Arts',
       selected_hits: [
         { 'name' => 'Esplanade de la Place des Arts', 'match' => false, 'description' => 'Montreal (QC) CA' }
@@ -15,7 +15,7 @@ class CcKgSelectionReasonTest < ActiveSupport::TestCase
   end
 
   def test_returns_province_when_selected_hit_matches_province
-    reason = CcKg::SelectionReason.for(
+    reason = Cckg::SelectionReason.for(
       query: 'Grand Theatre',
       selected_hits: [
         { 'name' => 'Grand Theatre Ontario', 'match' => false, 'description' => 'Sudbury (ON) CA' }
@@ -27,7 +27,7 @@ class CcKgSelectionReasonTest < ActiveSupport::TestCase
   end
 
   def test_returns_fallback_score_when_no_exact_or_province_match
-    reason = CcKg::SelectionReason.for(
+    reason = Cckg::SelectionReason.for(
       query: 'Grand Theatre',
       selected_hits: [
         { 'name' => 'Grand Theatre Quebec', 'match' => false, 'description' => 'Montreal (QC) CA' }


### PR DESCRIPTION

- replace inline CCKG logic with CcKg::Resolver calls
- centralize context extraction (province, city)
- remove redundant selection and filtering logic from helper
- keep behavior unchanged

This completes the transition of resolution logic from helper to service layer.